### PR TITLE
unify start, stop methods - references #3

### DIFF
--- a/mirakuru/exceptions.py
+++ b/mirakuru/exceptions.py
@@ -1,0 +1,16 @@
+
+
+class TimeoutExpired(Exception):
+
+    """This exception is raised when the timeout expires while starting
+    an executor.
+    """
+
+    def __init__(self, executor, timeout):
+        self.executor = executor
+        self.timeout = timeout
+
+    def __str__(self):
+        return 'Executor {0} timed out after {1} seconds'.format(
+            self.executor, self.timeout
+        )

--- a/mirakuru/executors/__init__.py
+++ b/mirakuru/executors/__init__.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with mirakuru.  If not, see <http://www.gnu.org/licenses/>.
 
-from mirakuru.executors.simple import SimpleExecutor, TimeoutExpired
+from mirakuru.executors.simple import SimpleExecutor
 from mirakuru.executors.output import OutputCoordinatedExecutor
 from mirakuru.executors.tcp import TCPCoordinatedExecutor
 from mirakuru.executors.http import HTTPCoordinatedExecutor
 
 __all__ = [
-    SimpleExecutor, TimeoutExpired, OutputCoordinatedExecutor,
+    SimpleExecutor, OutputCoordinatedExecutor,
     TCPCoordinatedExecutor, HTTPCoordinatedExecutor
 ]

--- a/mirakuru/executors/http.py
+++ b/mirakuru/executors/http.py
@@ -39,20 +39,19 @@ class HTTPCoordinatedExecutor(TCPCoordinatedExecutor):
 
     def start(self):
         TCPCoordinatedExecutor.start(self)
-        self._wait_for_successful_head()
+        self.wait_for(self._wait_for_successful_head)
 
     def _wait_for_successful_head(self):
-        while self.check_timeout():
-            try:
-                conn = httplib.HTTPConnection(self._url.hostname,
-                                              self._url.port)
+        try:
+            conn = httplib.HTTPConnection(self._url.hostname,
+                                          self._url.port)
 
-                conn.request('HEAD', self._url.path)
-                response = conn.getresponse()
+            conn.request('HEAD', self._url.path)
+            response = conn.getresponse()
 
-                if response.status is httplib.OK:
-                    conn.close()
-                    break
+            if response.status is httplib.OK:
+                conn.close()
+                return True
 
-            except (httplib.HTTPException, socket.timeout):
-                continue
+        except (httplib.HTTPException, socket.timeout):
+            return False

--- a/mirakuru/executors/output.py
+++ b/mirakuru/executors/output.py
@@ -28,9 +28,9 @@ class OutputCoordinatedExecutor(SimpleExecutor):
 
     def start(self):
         SimpleExecutor.start(self)
-        self._wait_for_output()
+        self.wait_for(self._wait_for_output)
 
     def _wait_for_output(self):
-        while self.check_timeout():
-            if self._banner.match(self.output().readline()):
-                break
+        if self._banner.match(self.output().readline()):
+            return True
+        return False

--- a/mirakuru/executors/tcp.py
+++ b/mirakuru/executors/tcp.py
@@ -30,14 +30,13 @@ class TCPCoordinatedExecutor(SimpleExecutor):
 
     def start(self):
         SimpleExecutor.start(self)
-        self._wait_for_connection()
+        self.wait_for(self._wait_for_connection)
 
     def _wait_for_connection(self):
-        while self.check_timeout():
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.connect((self._host, self._port))
-                break
+                return True
             except (socket.error, socket.timeout):
                 time.sleep(1)
-                continue
+                return False

--- a/tests/executors/test_http_coordinated_executor.py
+++ b/tests/executors/test_http_coordinated_executor.py
@@ -11,7 +11,8 @@ except ImportError:
     from http.client import HTTPConnection, OK
     http_server = "http.server"
 
-from mirakuru.executors import HTTPCoordinatedExecutor, TimeoutExpired
+from mirakuru.executors import HTTPCoordinatedExecutor
+from mirakuru.exceptions import TimeoutExpired
 
 
 class TestHTTPCoordinatedExecutor(TestCase):

--- a/tests/executors/test_tcp_coordinated_executor.py
+++ b/tests/executors/test_tcp_coordinated_executor.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
-from mirakuru.executors import TCPCoordinatedExecutor, TimeoutExpired
+from mirakuru.executors import TCPCoordinatedExecutor
+from mirakuru.exceptions import TimeoutExpired
 
 
 class TestTCPCoordinatedExecutor(TestCase):


### PR DESCRIPTION
- Okay, both start and stop are using wait.
- there's now extracted wait_for method, that takes care of waiting, killing and rising errors, so that wait condition methods can simply return True or False
- there's a constant timeout for stopping process set to 10 seconds. I'm still wandering if it shouldn't be configurable.
