### PR TITLE
contextmanager for stopping process only for given context

### DIFF
--- a/mirakuru/base.py
+++ b/mirakuru/base.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with mirakuru.  If not, see <http://www.gnu.org/licenses/>.
 """Base executor with the most basic functionality."""
-
+from contextlib import contextmanager
 import subprocess
 import shlex
 import time
@@ -140,6 +140,19 @@ class Executor(object):
 
             self.process = None
             self._endtime = None
+
+    @contextmanager
+    def stopped(self):
+        """
+        Stopping process for given context and starts it afterwards.
+
+        Allows for easier writing resistance integration tests whenever one of
+        the service fails.
+        """
+        if self.running():
+            self.stop()
+            yield
+            self.start()
 
     def kill(self, wait=True):
         """

--- a/tests/executors/test_executor.py
+++ b/tests/executors/test_executor.py
@@ -20,6 +20,18 @@ def test_running_context():
     assert executor.running() is False
 
 
+def test_context_stopped():
+    """Start for context, and shuts it for nested context."""
+    executor = Executor('sleep 300')
+    with executor:
+        assert executor.running() is True
+        with executor.stopped():
+            assert executor.running() is False
+        assert executor.running() is True
+
+    assert executor.running() is False
+
+
 def test_process_output():
     """Start process, check output and shut it down."""
     executor = Executor('echo -n "foobar"')


### PR DESCRIPTION
A general idea I've been thinking about since introducing starting context manager.

I'm still thinking about `stopped` vs `paused` and if stopped shouldn't raise an exception if called when stopped.
