### PR TITLE
Make version check work on python < 2.7

### DIFF
--- a/mirakuru/compat.py
+++ b/mirakuru/compat.py
@@ -22,7 +22,7 @@ import sys
 
 python = sys.executable
 
-if sys.version_info.major == 2:
+if sys.version_info[0] < 3:
     from httplib import HTTPConnection, HTTPException, OK
     from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
     from urlparse import urlparse


### PR DESCRIPTION
sys.version_info.major doesn't exist in python versions < 2.7. 