### PR TITLE
Detect subprocesses exiting erroneously while polling the checks

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,5 +10,6 @@ mirakuru along its history.
 * Grzegorz Śliwiński
 * Paweł Wilczyński
 * Daniel O'Connell
+* Michał Pawłowski
 
 Great thanks to `Mateusz Lenik <http://mlen.pl>`_ for original package!

--- a/mirakuru/__init__.py
+++ b/mirakuru/__init__.py
@@ -27,8 +27,10 @@ from mirakuru.http import HTTPExecutor
 from mirakuru.pid import PidExecutor
 
 from mirakuru.exceptions import (
+    ExecutorError,
     TimeoutExpired,
     AlreadyRunning,
+    ProcessExitedWithError,
 )
 
 __version__ = '0.5.0'
@@ -40,8 +42,10 @@ __all__ = (
     'TCPExecutor',
     'HTTPExecutor',
     'PidExecutor',
+    'ExecutorError',
     'TimeoutExpired',
     'AlreadyRunning',
+    'ProcessExitedWithError',
 )
 
 

--- a/mirakuru/exceptions.py
+++ b/mirakuru/exceptions.py
@@ -1,19 +1,32 @@
 """Mirakuru's exceptions."""
 
 
-class TimeoutExpired(Exception):
+class ExecutorError(Exception):
+
+    """Base exception for executor failures."""
+
+    def __init__(self, executor):
+        """
+        Exception initialization.
+
+        :param mirakuru.base.Executor executor: for which exception occured
+        """
+        super(ExecutorError, self).__init__(self)
+        self.executor = executor
+
+
+class TimeoutExpired(ExecutorError):
 
     """Is raised when the timeout expires while starting an executor."""
 
     def __init__(self, executor, timeout):
         """
-        Exception initialization.
+        Exception initialization with an extra ``timeout`` argument.
 
-        :param mirakuru.base.Executor executor: for which exception occured.
-        :param int timeout: timeout for which exception occurred.
+        :param mirakuru.base.Executor executor: for which exception occured
+        :param int timeout: timeout for which exception occurred
         """
-        super(self.__class__, self).__init__()
-        self.executor = executor
+        super(TimeoutExpired, self).__init__(executor)
         self.timeout = timeout
 
     def __str__(self):
@@ -28,7 +41,7 @@ class TimeoutExpired(Exception):
         )
 
 
-class AlreadyRunning(Exception):
+class AlreadyRunning(ExecutorError):
 
     """
     Is raised when the executor seems to be already running.
@@ -36,15 +49,6 @@ class AlreadyRunning(Exception):
     When some other process (not necessary executor) seems to be started with
     same configuration we can't bind to same port.
     """
-
-    def __init__(self, executor):
-        """
-        Exception initialization.
-
-        :param mirakuru.base.Executor executor: for which exception occured.
-        """
-        super(self.__class__, self).__init__()
-        self.executor = executor
 
     def __str__(self):
         """
@@ -57,4 +61,36 @@ class AlreadyRunning(Exception):
                 "It looks like the previous executor process hasn't been "
                 "terminated or killed. Also there might be some completely "
                 "different service listening on {exc.executor.port} port."
+                .format(exc=self))
+
+
+class ProcessExitedWithError(ExecutorError):
+
+    """
+    Raised when the process invoked by the executor returns a non-zero code.
+
+    We allow the process to exit with zero because we support daemonizing
+    subprocesses. We assume that when double-forking, the parent process will
+    exit with 0 in case of successfull daemonization.
+    """
+
+    def __init__(self, executor, exit_code):
+        """
+        Exception initialization with an extra ``exit_code`` argument.
+
+        :param mirakuru.base.Executor executor: for which exception occured
+        :param int exit_code: code the subprocess exited with
+        """
+        super(ProcessExitedWithError, self).__init__(executor)
+        self.exit_code = exit_code
+
+    def __str__(self):
+        """
+        Return Exception's string representation.
+
+        :returns: string representation
+        :rtype: str
+        """
+        return ("The process invoked by the {exc.executor} executor has "
+                "exited with a non-zero code: {exc.exit_code}."
                 .format(exc=self))

--- a/tests/executors/test_pid_executor.py
+++ b/tests/executors/test_pid_executor.py
@@ -8,7 +8,7 @@ from mirakuru import TimeoutExpired, AlreadyRunning
 
 
 filename = "pid-test-tmp{0}".format(os.getpid())
-sleep = 'bash -c "sleep 2 && touch {0}"'.format(filename)
+sleep = 'bash -c "sleep 1 && touch {0} && sleep 1"'.format(filename)
 
 
 @pytest.yield_fixture(autouse=True)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,5 +10,7 @@ def test_importing_mirakuru():
     assert TCPExecutor
     assert HTTPExecutor
     assert PidExecutor
+    assert ExecutorError
     assert TimeoutExpired
     assert AlreadyRunning
+    assert ProcessExitedWithError


### PR DESCRIPTION
Raise ProcessExitedWithError if the main subprocess exits with a non-zero code while polling the checks.

It's 1 AM so I think this counts as a preview.