### PR TITLE
#59 Set the default 'timeout' value for the SimpleExecutor.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ unreleased
 ----------
 
 - [feature] Detect subprocesses exiting erroneously while polling the checks and error early.
+- [change] Set the default 'timeout' value for the SimpleExecutor.
+  The SimpleExecutor has now default timeout equal 30 seconds (previously None).
+  In the most of cases 30 seconds seems to be reasonable for a process to start or stop.
+- [change] Reduced the default 'sleep' value of SimpleExecutor from 0.1 to 0.01 seconds.
+  In case of huge number of tests having many mirakuru executors library users can benefit from
+  the the faster response on start() or stop().
+
 
 0.5.0
 ----------

--- a/mirakuru/base.py
+++ b/mirakuru/base.py
@@ -81,7 +81,7 @@ class SimpleExecutor(object):
     ENV_UUID = 'mirakuru_uuid'
 
     def __init__(
-            self, command, shell=False, timeout=None, sleep=0.1,
+            self, command, shell=False, timeout=30, sleep=0.01,
             sig_stop=signal.SIGTERM, sig_kill=signal.SIGKILL
     ):
         """


### PR DESCRIPTION
- The SimpleExecutor has now default timeout equal 30 seconds (previously None).
  In the most of cases 30 seconds seems reasonable to for a process to start or stop.
- Reduced the default 'sleep' value of SimpleExecutor from 0.1 to 0.01 seconds.
  In case of huge number of tests having many mirakuru executors library users can benefit from
  the the faster response on start() or stop().