### PR TITLE
Fix test_forgotten_stop by forcing bash to `fork` when it tries to be smart and just `execve`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ unreleased
 ----------
 
 - [feature] Detect subprocesses exiting erroneously while polling the checks and error early.
+- [fix] make test_forgotten_stop pass by preventing the shell from optimizing forking out
 
 0.5.0
 ----------


### PR DESCRIPTION
When running a subprocess with `shell=True`, the command is passed to a system-depedent shell. On Ubuntu `/bin/sh` resolves to `dash`. On Fedora it links to `bash`. Bash tends to be lazy and kind of smart so if it sees that only one command is going to be `sleep`, it doesn't bother creating a child process and returning its exit value - it simply replaces itself with that process. 

Straces from my little Fedora machine (`Linux DziadFedoraM 3.19.8-100.fc20.x86_64 #1 SMP Tue May 12 17:08:50 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux`):

No forced clone:
```
$ strace -f -e trace=process bash -c 'sleep 1'
execve("/usr/bin/bash", ["bash", "-c", "sleep 1"], [/* 64 vars */]) = 0
arch_prctl(ARCH_SET_FS, 0x7fdfe9005740) = 0
execve("/usr/bin/sleep", ["sleep", "1"], [/* 63 vars */]) = 0
arch_prctl(ARCH_SET_FS, 0x7f103dcb3740) = 0
exit_group(0)                           = ?
+++ exited with 0 +++
```

Forcing clone by injecting some flow control to the command:
```
$ strace -f -e trace=process bash -c 'sleep 1 && true'
execve("/usr/bin/bash", ["bash", "-c", "sleep 1 && true"], [/* 64 vars */]) = 0
arch_prctl(ARCH_SET_FS, 0x7f7e6df2f740) = 0
clone(child_stack=0, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7f7e6df2fa10) = 28305
Process 28305 attached
[pid 28305] execve("/usr/bin/sleep", ["sleep", "1"], [/* 63 vars */] <unfinished ...>
[pid 28304] wait4(-1,  <unfinished ...>
[pid 28305] <... execve resumed> )      = 0
[pid 28305] arch_prctl(ARCH_SET_FS, 0x7f0d36f30740) = 0
[pid 28305] exit_group(0)               = ?
[pid 28305] +++ exited with 0 +++
<... wait4 resumed> [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], 0, NULL) = 28305
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=28305, si_uid=1000, si_status=0, si_utime=0, si_stime=0} ---
wait4(-1, 0x7ffe462e4690, WNOHANG, NULL) = -1 ECHILD (No child processes)
exit_group(0)                           = ?
+++ exited with 0 +++
```


The above is pretty solid. Now the uncertain part:
1. On Fedora when explicitly invoking `dash`, the behaviour is the same as `bash` - no fork when not needed.
2. I downloaded and booted a Vagrant Ubuntu Trusty 32bit box and noticed that `bash` optimizes forking out but `dash` does not.
3. The difference between those 2 dashes is only one version (0.5.7 on Ubuntu, 0.5.8 on Fedora). I cloned, checked the Ubuntu version and built `dash` from source and noticed that even in 0.5.7 the fork gets optimized. The optimisation commit comes from 2011 and belongs to both versions. So it may be a Ubuntu thing that breaks this optimisation (and makes the test pass).