### PR TITLE
Rough partial implementation of the CLI (DO NOT MERGE)

### DIFF
--- a/mirakuru/__init__.py
+++ b/mirakuru/__init__.py
@@ -35,17 +35,20 @@ from mirakuru.exceptions import (
 
 __version__ = '0.5.0'
 
-__all__ = (
-    'Executor',
-    'SimpleExecutor',
-    'OutputExecutor',
-    'TCPExecutor',
-    'HTTPExecutor',
-    'PidExecutor',
-    'ExecutorError',
-    'TimeoutExpired',
-    'AlreadyRunning',
-    'ProcessExitedWithError',
+all_executors = (
+    Executor,
+    SimpleExecutor,
+    OutputExecutor,
+    TCPExecutor,
+    HTTPExecutor,
+    PidExecutor,
+)
+
+all_exceptions = (
+    ExecutorError,
+    TimeoutExpired,
+    AlreadyRunning,
+    ProcessExitedWithError,
 )
 
 

--- a/mirakuru/cli.py
+++ b/mirakuru/cli.py
@@ -1,0 +1,43 @@
+"""Command line interface for executor invocations."""
+import sys
+import time
+
+from argparse import ArgumentParser
+from mirakuru import all_executors
+
+
+parser = ArgumentParser(description='Execute a process, check when actually '
+                        'starts working and terminate the process when '
+                        'terminating `mirakuru` due to a received signal.')
+subcommands = parser.add_subparsers()
+
+for executor_class in all_executors:
+    name = executor_class.CLI_NAME
+    if name is not None:
+        executor_subcommand = subcommands.add_parser(name)
+        executor_class.populate_command(executor_subcommand)
+        executor_subcommand.set_defaults(func=executor_class.as_command)
+
+
+def cli_entry():
+    """Dispatch and run the executor."""
+    args = sys.argv[1:]
+    # Find the '--' separator that splits the executor command line and the
+    # one of the executed process.
+    try:
+        separator = args.index('--')
+    except ValueError:
+        print '-- needed'
+        return
+
+    executor_args, process_args = args[:separator], args[separator + 1:]
+
+    args = parser.parse_args(executor_args)
+    args.process_args = process_args
+    args.func(args)
+
+    # Here we should probably sleep indefinitely and handle signals sent to
+    # mirakuru to be able to exit.
+    # Or maybe exit (with an error?) when the subprocess exits.
+    print 'checks passed'
+    time.sleep(100000)

--- a/mirakuru/http.py
+++ b/mirakuru/http.py
@@ -29,6 +29,8 @@ class HTTPExecutor(TCPExecutor):
 
     """Http enabled process executor."""
 
+    CLI_NAME = 'http'
+
     def __init__(self, command, url, **kwargs):
         """
         Initialize HTTPExecutor executor.

--- a/mirakuru/output.py
+++ b/mirakuru/output.py
@@ -27,6 +27,8 @@ class OutputExecutor(SimpleExecutor):
 
     """Executor that awaits for string output being present in output."""
 
+    CLI_NAME = 'output'
+
     def __init__(self, command, banner, **kwargs):
         """
         Initialize OutputExecutor executor.

--- a/mirakuru/pid.py
+++ b/mirakuru/pid.py
@@ -31,6 +31,8 @@ class PidExecutor(Executor):
     created.
     """
 
+    CLI_NAME = 'pid'
+
     def __init__(self, command, filename, **kwargs):
         """
         Initialize the PidExecutor executor.

--- a/mirakuru/signals.py
+++ b/mirakuru/signals.py
@@ -1,0 +1,20 @@
+"""A mapping of signals from the `signals` library`."""
+import signal
+
+signal_name_to_code = {}
+"""
+A map of signal names to codes like: `'SIGTERM': 15`.
+
+.. note ::
+    The reverse mapping may have repeating elements.
+"""
+
+known_signals_codes = set()
+"""A list of codes of signals in the `signal` library."""
+
+
+for signals_global in dir(signal):
+    if signals_global.startswith('SIG'):
+        signal_code = getattr(signal, signals_global)
+        signal_name_to_code[signals_global] = signal_code
+        known_signals_codes.add(signal_code)

--- a/mirakuru/tcp.py
+++ b/mirakuru/tcp.py
@@ -30,6 +30,28 @@ class TCPExecutor(Executor):
     TCP connections.
     """
 
+    CLI_NAME = 'tcp'
+
+    @classmethod
+    def populate_command(cls, command):
+        """
+        Populate the executor subcommand with the arguments.
+
+        Including TCPExecutor-specific args.
+        """
+        super(TCPExecutor, cls).populate_command(command)
+        command.add_argument('host', type=str, help='process host')
+        command.add_argument('port', type=int, help='process port')
+
+    @classmethod
+    def commandline_args_to_init_keyword_args(cls, args):
+        """Form kwargs dict for cls.__init__ with TCPExecutor-specific args."""
+        init_args = super(TCPExecutor, cls).\
+            commandline_args_to_init_keyword_args(args)
+        init_args['port'] = args.port
+        init_args['host'] = args.host
+        return init_args
+
     def __init__(self, command, host, port, **kwargs):
         """
         Initialize TCPExecutor executor.

--- a/setup.py
+++ b/setup.py
@@ -85,4 +85,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     extras_require=extras_require,
+    entry_points={
+        'console_scripts': 'mirakuru=mirakuru.cli:cli_entry'
+    },
 )


### PR DESCRIPTION
The separation of mirakuru and executed process arguments is currently done manually,

There is a 'better' approach to the '--' separator - argparse supports it because '--' is traditionally used to separate positional arguments from optional. So it is possible to specify a terminating positional argument with `nargs='*'`, which would cause it to consume everything after the optional `--` separator and everything before that is not a mirakuru-defined argument (or some default, like `-h`) - this is actually a downside because this causes  `--bad-arg` to be passed to the `executor_command` in  `mirakuru --good-arg --bad-arg -- executor_command`). The benefit, on the other hand is that we don't have to hack the help messages to display info about the `executor_command` as the command argument is handled by argparse.

I have written a more stupid code than I initially wanted to because the mapping between `__init__` arguments and the CLI is not so trivial as I imagined. Also CLI turns out to have different needs.

What works: e.g. `$ mirakuru tcp 127.0.0.1 8000  -- python -m SimpleHTTPServer`


I'm looking for general feedback. Please don't give comments like 'docstring needed', etc., because what's done is like 65% of thinking and 30% of writing the code.