### PR TITLE
Pass default port to the TCP check from HTTPExecutor

### DIFF
--- a/mirakuru/http.py
+++ b/mirakuru/http.py
@@ -29,6 +29,9 @@ class HTTPExecutor(TCPExecutor):
 
     """Http enabled process executor."""
 
+    DEFAULT_PORT = 80
+    """Default TCP port in the HTTP protocol."""
+
     def __init__(self, command, url, **kwargs):
         """
         Initialize HTTPExecutor executor.
@@ -50,16 +53,21 @@ class HTTPExecutor(TCPExecutor):
         """
         An :func:`urlparse.urlparse` representation of an url.
 
-        It'll be used to check process status on."""
+        It'll be used to check process status on.
+        """
+
+        port = self.url.port
+        if port is None:
+            port = self.DEFAULT_PORT
 
         super(HTTPExecutor, self).__init__(
-            command, host=self.url.hostname, port=self.url.port, **kwargs
+            command, host=self.url.hostname, port=port, **kwargs
         )
 
     def after_start_check(self):
         """Check if defined url returns successful head."""
         try:
-            conn = HTTPConnection(self.url.hostname, self.url.port)
+            conn = HTTPConnection(self.host, self.port)
 
             conn.request('HEAD', self.url.path)
             response = conn.getresponse()


### PR DESCRIPTION
If there was no port in the URL, None was passed to the TCP check which
raised an exception. Now 80 is passed by default.

```
In [4]: e = HTTPExecutor('true', 'http://example.com', timeout=10)

In [5]: e.start()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-551dec880240> in <module>()
----> 1 e.start()

/home/mp/IDE/mirakuru/mirakuru/base.py in start(self)
    387         (executor) and wait until it's started.
    388         """
--> 389         if self.pre_start_check():
    390             # Some other executor (or process) is running with same config:
    391             raise AlreadyRunning(self)

/home/mp/IDE/mirakuru/mirakuru/tcp.py in pre_start_check(self)
     65         try:
     66             sock = socket.socket()
---> 67             sock.connect((self.host, self.port))
     68             return True
     69         except (socket.error, socket.timeout):

/usr/lib64/python2.7/socket.pyc in meth(name, self, *args)
    226 
    227 def meth(name,self,*args):
--> 228     return getattr(self._sock,name)(*args)
    229 
    230 for _m in _socketmethods:

TypeError: an integer is required

In [6]: e.p
e.port             e.pre_start_check  e.process          

In [6]: e.port

In [7]: e.host
Out[7]: 'example.com'
```