### PR TITLE
fix for python-daemon updated functionality

### DIFF
--- a/tests/sample_daemon.py
+++ b/tests/sample_daemon.py
@@ -19,7 +19,7 @@ sys.path.append(os.getcwd())  # noqa
 from tests.signals import block_signals
 
 
-with daemon.DaemonContext():
+with daemon.DaemonContext(initgroups=False):
     block_signals()
     while True:
         print('Sleeping mirakuru daemon...')


### PR DESCRIPTION
- cases breakega using settings requiring root priviledges by default