### PR TITLE
[PREVIEW] Show the possibly listening process in the AlreadyRunning exception message

### DIFF
--- a/src/mirakuru/exceptions.py
+++ b/src/mirakuru/exceptions.py
@@ -1,5 +1,7 @@
 """Mirakuru exceptions."""
 
+import psutil
+
 
 class ExecutorError(Exception):
     """Base exception for executor failures."""
@@ -45,7 +47,42 @@ class AlreadyRunning(ExecutorError):
 
     When some other process (not necessary executor) seems to be started with
     same configuration we can't bind to same port.
+
+    The exception message is less useful for executors not using TCP ports.
     """
+
+    def __init__(self, executor):
+        """
+        Initialize and detect what service is listening on the configured port.
+
+        :param mirakuru.base.Executor executor: for which exception occurred
+        """
+        super(AlreadyRunning, self).__init__(executor)
+        try:
+            self.port = getattr(executor, 'port')
+        except AttributeError:
+            self.port = None
+        if self.port:
+            # The pid field contains an integer process ID or None if the
+            # process belongs to a different user. Multiple processes can
+            # listen on the same port.
+            pids = [
+                sconn.pid
+                for sconn in psutil.net_connections(kind='tcp')
+                if sconn.pid and sconn.laddr[1] == self.port]
+            processes = []
+            for pid in pids:
+                try:
+                    processes.append(
+                        '%r[%d]' % (psutil.Process(pid).cmdline(), pid))
+                except psutil.NoSuchProcess:
+                    processes.append('exited[%d]' % pid)
+            if not processes:
+                self.listening_service = '[unknown]'
+            else:
+                self.listening_service = ' '.join(processes)
+        else:
+            self.listening_service = '[unknown]'
 
     def __str__(self):
         """
@@ -57,7 +94,8 @@ class AlreadyRunning(ExecutorError):
         return ("Executor {exc.executor} seems to be already running. "
                 "It looks like the previous executor process hasn't been "
                 "terminated or killed. Also there might be some completely "
-                "different service listening on {exc.executor.port} port."
+                "different service listening on {exc.port} port. Services "
+                "found running on that port: {exc.listening_service}."
                 .format(exc=self))
 
 

--- a/tests/executors/test_http_executor.py
+++ b/tests/executors/test_http_executor.py
@@ -2,6 +2,7 @@
 import sys
 import socket
 from functools import partial
+import shlex
 
 import pytest
 from mock import patch
@@ -124,6 +125,9 @@ def test_fail_if_other_executor_running():
             with executor2:
                 pass
         assert 'seems to be already running' in str(exc)
+        expected_process = '%r[%d]' % (
+            shlex.split(http_server_cmd), executor.process.pid)
+        assert expected_process in str(exc)
 
 
 @patch.object(HTTPExecutor, 'DEFAULT_PORT', PORT)


### PR DESCRIPTION
refs #133

What I think must be changed before it's mergable:

* we should not have the same `AlreadyRunning` in `Executor` (which is used also for `PIDExecutor` and could be used e.g. for Unix socket executors; these don't have port numbers): we could instead subclass it to add the port number and the new message in an exception specific to the `TCPExecutor`
* we should find the responsible process in the `TCPExecutor`, not the exception class
* since there are potential race conditions (e.g. a listening process exists between us checking if the port is available and reporting the exception message), we might want to retry the check in some cases