### PR TITLE
Ignore ProcessLookupError when killing processes

### DIFF
--- a/src/mirakuru/base.py
+++ b/src/mirakuru/base.py
@@ -226,7 +226,10 @@ class SimpleExecutor(object):
         pids = processes_with_env(ENV_UUID, self._uuid)
         for pid in pids:
             log.debug("Killing process %d ...", pid)
-            os.kill(pid, sig)
+            try:
+                os.kill(pid, sig)
+            except ProcessLookupError:
+                pass
             log.debug("Killed process %d.", pid)
         return pids
 

--- a/src/mirakuru/base.py
+++ b/src/mirakuru/base.py
@@ -229,6 +229,7 @@ class SimpleExecutor(object):
             try:
                 os.kill(pid, sig)
             except ProcessLookupError:
+                # the process has died before we tried to kill it.
                 pass
             log.debug("Killed process %d.", pid)
         return pids

--- a/src/mirakuru/base.py
+++ b/src/mirakuru/base.py
@@ -230,7 +230,7 @@ class SimpleExecutor(object):
             try:
                 os.kill(pid, sig)
             except OSError as err:
-                if err.errno != errno.ESRCH:
+                if err.errno == errno.ESRCH:
                     # the process has died before we tried to kill it.
                     pass
                 else:

--- a/src/mirakuru/base.py
+++ b/src/mirakuru/base.py
@@ -26,6 +26,7 @@ import signal
 import subprocess
 import time
 import uuid
+import errno
 
 from mirakuru.base_env import processes_with_env
 from mirakuru.exceptions import (
@@ -228,9 +229,12 @@ class SimpleExecutor(object):
             log.debug("Killing process %d ...", pid)
             try:
                 os.kill(pid, sig)
-            except ProcessLookupError:
-                # the process has died before we tried to kill it.
-                pass
+            except OSError as err:
+                if err.errno != errno.ESRCH:
+                    # the process has died before we tried to kill it.
+                    pass
+                else:
+                    raise
             log.debug("Killed process %d.", pid)
         return pids
 


### PR DESCRIPTION
This is a fix for https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/39.

It removes an error if the process dies just before mirakuru tries to kill it.