### PR TITLE
Fix select.poll type annotation for Mac OS

### DIFF
--- a/src/mirakuru/output.py
+++ b/src/mirakuru/output.py
@@ -133,7 +133,7 @@ class OutputExecutor(SimpleExecutor):
                 return True
         return False
 
-    def _wait_for_output(self, *polls: Tuple[select.poll, IO[Any]]) -> bool:
+    def _wait_for_output(self, *polls: Tuple['select.poll', IO[Any]]) -> bool:
         """
         Check if output matches banner.
 


### PR DESCRIPTION
Addresses #373 by adding quotes to the `select.poll` type annotation.