### PR TITLE
Check exit code on `stop()`

### DIFF
--- a/src/mirakuru/base.py
+++ b/src/mirakuru/base.py
@@ -38,6 +38,7 @@ from mirakuru.base_env import processes_with_env
 from mirakuru.exceptions import (
     AlreadyRunning,
     ProcessExitedWithError,
+    ProcessFinishedWithError,
     TimeoutExpired,
 )
 from mirakuru.compat import SIGKILL
@@ -349,7 +350,7 @@ class SimpleExecutor:  # pylint:disable=too-many-instance-attributes
         # don't treat that as an error.
         # pylint: disable=invalid-unary-operand-type
         if exit_code and exit_code != -sig:
-            raise ProcessExitedWithError(self, exit_code)
+            raise ProcessFinishedWithError(self, exit_code)
 
         return self
 

--- a/src/mirakuru/exceptions.py
+++ b/src/mirakuru/exceptions.py
@@ -101,3 +101,12 @@ class ProcessExitedWithError(ExecutorError):
         """
         return (f"The process invoked by the {self.executor} executor has "
                 f"exited with a non-zero code: {self.exit_code}.")
+
+
+class ProcessFinishedWithError(ProcessExitedWithError):
+    """
+    Raised when the process invoked by the executor fails when stopping.
+
+    When a process is stopped, it should shut down cleanly and return zero as
+    exit code. When is returns a non-zero exit code, this exception is raised.
+    """

--- a/tests/executors/test_executor_kill.py
+++ b/tests/executors/test_executor_kill.py
@@ -13,7 +13,7 @@ import pytest
 
 from mirakuru import SimpleExecutor, HTTPExecutor
 from mirakuru.compat import SIGKILL
-from mirakuru.exceptions import ProcessExitedWithError
+from mirakuru.exceptions import ProcessFinishedWithError
 
 from tests import SAMPLE_DAEMON_PATH, ps_aux, TEST_SERVER_PATH
 
@@ -40,7 +40,7 @@ def test_kill_custom_signal_kill():
 
 def test_already_closed():
     """Check that the executor cleans after itself after it exited earlier."""
-    with pytest.raises(ProcessExitedWithError) as excinfo:
+    with pytest.raises(ProcessFinishedWithError) as excinfo:
         with SimpleExecutor('python') as executor:
             assert executor.running()
             os.killpg(executor.process.pid, SIGKILL)

--- a/tests/executors/test_executor_kill.py
+++ b/tests/executors/test_executor_kill.py
@@ -9,8 +9,11 @@ import errno
 import os
 from unittest.mock import patch
 
+import pytest
+
 from mirakuru import SimpleExecutor, HTTPExecutor
 from mirakuru.compat import SIGKILL
+from mirakuru.exceptions import ProcessExitedWithError
 
 from tests import SAMPLE_DAEMON_PATH, ps_aux, TEST_SERVER_PATH
 
@@ -37,15 +40,17 @@ def test_kill_custom_signal_kill():
 
 def test_already_closed():
     """Check that the executor cleans after itself after it exited earlier."""
-    with SimpleExecutor('python') as executor:
-        assert executor.running()
-        os.killpg(executor.process.pid, SIGKILL)
+    with pytest.raises(ProcessExitedWithError) as excinfo:
+        with SimpleExecutor('python') as executor:
+            assert executor.running()
+            os.killpg(executor.process.pid, SIGKILL)
 
-        def process_stopped():
-            """Return True only only when self.process is not running."""
-            return executor.running() is False
-        executor.wait_for(process_stopped)
-        assert executor.process
+            def process_stopped():
+                """Return True only only when self.process is not running."""
+                return executor.running() is False
+            executor.wait_for(process_stopped)
+            assert executor.process
+    assert excinfo.value.exit_code == -9
     assert not executor.process
 
 


### PR DESCRIPTION
We should notice when a process does not manage to stop cleanly. Since
mirakuru checks the exit code in other places and raises
`ProcessExitedWithError` when it's not zero, doing this during stop
makes sense, too.

Closes https://github.com/ClearcodeHQ/mirakuru/issues/380.