### PR TITLE
Allow TMPDIR for tests

### DIFF
--- a/newsfragments/810.misc.rst
+++ b/newsfragments/810.misc.rst
@@ -1,0 +1,1 @@
+Allow TMPDIR for tests.

--- a/tests/executors/test_unixsocket_executor.py
+++ b/tests/executors/test_unixsocket_executor.py
@@ -4,6 +4,7 @@ Some of these tests run ``nc``: when running Debian, make sure the
 ``netcat-openbsd`` package is used, not ``netcat-traditional``.
 """
 
+import os
 import sys
 
 import pytest
@@ -12,7 +13,7 @@ from mirakuru import TimeoutExpired
 from mirakuru.unixsocket import UnixSocketExecutor
 from tests import TEST_SOCKET_SERVER_PATH
 
-SOCKET_PATH = "/tmp/mirakuru.sock"
+SOCKET_PATH = os.path.join(os.getenv("TMPDIR", "/tmp"), "mirakuru.sock")
 
 SOCKET_SERVER_CMD = f"{sys.executable} {TEST_SOCKET_SERVER_PATH} {SOCKET_PATH}"
 


### PR DESCRIPTION
On NixOS, /tmp is not writeable and TMPDIR is set. Use that instead.

Failure log without this patch: https://hydra.nixos.org/build/275642339/nixlog/1