### PR TITLE
Add Python 3.15 to the CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     uses: fizyk/actions-reuse/.github/workflows/shared-tests-pytests.yml@a77b9a9554742fe1ad70b0c0cd589235fd0a60fb # v5.2.1
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy-3.11"]'
       dependency-manager: 'uv'
       pytest_opts: '-n auto --dist loadgroup'
     secrets:
@@ -19,7 +19,7 @@ jobs:
     uses: fizyk/actions-reuse/.github/workflows/shared-tests-pytests.yml@a77b9a9554742fe1ad70b0c0cd589235fd0a60fb # v5.2.1
     needs: [tests]
     with:
-      python-versions: '["3.12", "3.13", "3.14", "pypy-3.11"]'
+      python-versions: '["3.12", "3.13", "3.14", "3.15", "pypy-3.11"]'
       dependency-manager: 'uv'
       pytest_opts: '-n auto --dist loadgroup --basetemp=$RUNNER_TEMP/pt'
       os: macos-14 # macos-latest is on macos-15 which misbehaves'
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy-3.11"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up UV on python ${{ matrix.python-version }}

--- a/newsfragments/+6d644cc8.misc.rst
+++ b/newsfragments/+6d644cc8.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.15 to the CI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to test compatibility with Python 3.13, 3.14, and 3.15 alongside existing supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->