### PR TITLE
Nudge stuck dependabot PRs on a schedule

### DIFF
--- a/.github/workflows/dependabot-nudge.yml
+++ b/.github/workflows/dependabot-nudge.yml
@@ -1,0 +1,117 @@
+name: Nudge stuck dependabot PRs
+
+# Automerge only runs when a workflow_run/check_suite completes. A dependabot
+# PR that goes green without such an event - or whose merge was refused once -
+# is never looked at again, and with open-pull-requests-limit it head-blocks
+# every following update. Poke those PRs so dependabot pushes a fresh commit,
+# which re-runs the checks and re-triggers automerge.
+
+on:
+  schedule:
+    # Half an hour after the dependabot slots, and late enough in the evening
+    # to catch a pre-commit.ci autoupdate; the two remaining runs pick up
+    # anything requested by hand in between.
+    - cron: '45 5,11,17,23 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Only log which PRs would be nudged'
+        type: boolean
+        default: false
+      quiet-hours:
+        description: 'Hours a PR must sit untouched before it is nudged'
+        type: string
+        default: '3'
+
+permissions: {}
+
+jobs:
+  nudge:
+    name: Nudge me!
+    runs-on: ubuntu-latest
+    steps:
+      - name: Impersonate update bot
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          client-id: ${{ secrets.MERGE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+          # contents for the default branch tip, checks and statuses for the
+          # rollup - pre-commit.ci reports a commit status, not a check run.
+          permission-contents: read
+          permission-checks: read
+          permission-statuses: read
+          permission-metadata: read
+      - name: Nudge me!
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          # A nudge restarts the whole check matrix, so leave a pull request
+          # alone for this long after its last update before nudging again.
+          QUIET_HOURS: ${{ inputs.quiet-hours || '3' }}
+        run: |
+          set -euo pipefail
+
+          gh api graphql \
+            -F owner="${GH_REPO%/*}" -F name="${GH_REPO#*/}" \
+            -f query='
+              query($owner: String!, $name: String!) {
+                repository(owner: $owner, name: $name) {
+                  defaultBranchRef { target { oid } }
+                  pullRequests(states: OPEN, first: 50) {
+                    nodes {
+                      number
+                      updatedAt
+                      baseRefOid
+                      isDraft
+                      author { login }
+                      commits(last: 1) {
+                        nodes { commit { statusCheckRollup { state } } }
+                      }
+                    }
+                  }
+                }
+              }' > pulls.json
+
+          # Guard against a token that cannot read what the query asks for:
+          # an unreadable tip or rollup would otherwise silently select nobody.
+          tip=$(jq -r '.data.repository.defaultBranchRef.target.oid // empty' pulls.json)
+          if [ -z "${tip}" ]; then
+            echo 'Cannot read the default branch tip - token missing contents: read?' >&2
+            exit 1
+          fi
+          jq -r '.data.repository.pullRequests.nodes[]
+            | select(.author.login | test("^dependabot(\\[bot\\])?$"))
+            | "#\(.number) rollup=\(.commits.nodes[0].commit.statusCheckRollup.state // "unreadable")"
+            ' pulls.json
+
+          # A PR based on something other than the current default branch tip
+          # only needs catching up; one that is already current needs a new
+          # commit to generate check runs at all, hence recreate.
+          jq -r --arg tip "${tip}" '
+            .data.repository.pullRequests.nodes[]
+            | select(.author.login | test("^dependabot(\\[bot\\])?$"))
+            | select(.isDraft | not)
+            | select(.commits.nodes[0].commit.statusCheckRollup.state == "SUCCESS")
+            | [
+                .number,
+                .updatedAt,
+                (if .baseRefOid == $tip then "recreate" else "rebase" end)
+              ]
+            | @tsv' pulls.json > candidates.tsv
+
+          cutoff=$(date -u -d "-${QUIET_HOURS} hours" +%s)
+
+          while IFS=$'\t' read -r number updated command; do
+            if [ "$(date -u -d "${updated}" +%s)" -gt "${cutoff}" ]; then
+              echo "#${number}: updated ${updated}, inside the ${QUIET_HOURS}h quiet window, skipping."
+              continue
+            fi
+            echo "#${number}: green and idle since ${updated}, asking for a ${command}."
+            if [ "${DRY_RUN:-false}" = 'true' ]; then
+              continue
+            fi
+            gh pr comment "${number}" --body "@dependabot ${command}"
+          done < candidates.tsv

--- a/newsfragments/+7f3ac1d9.misc.rst
+++ b/newsfragments/+7f3ac1d9.misc.rst
@@ -1,0 +1,1 @@
+Nudge stuck dependabot pull requests back into the automerge flow


### PR DESCRIPTION
Automerge only fires on workflow_run/check_suite completions. A dependabot PR that goes green without one - or whose merge got refused once, as with the workflow_updates guard on a three-way merge of .github/workflows - is never revisited, and with open-pull-requests-limit it head-blocks every following update.

Comment @dependabot rebase (stale base) or @dependabot recreate (base already current) on green, idle dependabot PRs so a fresh commit re-runs the checks and re-triggers automerge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated handling to nudge eligible stalled dependency update pull requests back into the merge workflow.
  * Introduced scheduled and manual operation, including support for dry-run and quiet-hours to control when nudges are applied.
* **Documentation**
  * Added a release note covering the improved handling of stalled dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->